### PR TITLE
11-29-2019

### DIFF
--- a/src/danmu/bilibilisocket.js
+++ b/src/danmu/bilibilisocket.js
@@ -270,14 +270,8 @@ class GuardMonitor extends BilibiliSocket {
 
     onPopularity(popularity) {
         if (popularity <= 1) {
-            Bilibili.isLive(this.roomid).then(streaming => {
-                if (streaming === false) {
-                    ++this.offTimes;
-                    if (this.offTimes > 3) super.close();
-                }
-            }).catch(error => {
-                cprint(`${Bilibili.isLive.name} - ${error}`, colors.red);
-            });
+            ++this.offTimes;
+            if (this.offTimes > 10) super.close();
         } else {
             this.offTimes = 0;
         }


### PR DESCRIPTION
舰长房间不使用API下播判定 避免递归超负荷

每30秒几千个房间发送请求... 每个房间递归至少100次
累积起来确实会超出堆栈峰值