### PR TITLE
12-01-2019

### DIFF
--- a/src/danmu/bilibilisocket.js
+++ b/src/danmu/bilibilisocket.js
@@ -92,6 +92,16 @@ class BilibiliSocket {
         this.buffer = Buffer.concat([ this.buffer, buffer ]);
         if (this.totalLength <= 0 && this.buffer.length >= 4)
             this.totalLength = this.buffer.readUInt32BE(0);
+        if (this.totalLength > 100000) {
+            ++config.error['count'];
+            if (config.error['count'] > 100) {
+                cprint(`Fatal Error: 错误次数超过100 (${config.error['count']})`, colors.red);
+                cprint(`Fatal Error: b站服务器拒绝连接`, colors.red);
+                cprint(`程序终止`, colors.red);
+                process.exit(1);
+            }
+            this.close();
+        }
         if (config.debug === true)
             cprint(`BufferSize ${this.buffer.length} Length ${this.totalLength}`, colors.green);
         while (this.totalLength > 0 && this.buffer.length >= this.totalLength) {

--- a/src/danmu/controller.js
+++ b/src/danmu/controller.js
@@ -2,6 +2,7 @@
 
 const colors = require('colors/safe');
 
+const config = require('../global/config.js');
 const cprint = require('../util/printer.js');
 const Bilibili = require('../bilibili.js');
 const {
@@ -56,7 +57,7 @@ class GuardController {
                         const roomid = roomInfo['roomid'];
                         const online = roomInfo['online'];
 
-                        if (online > 10 
+                        if (online > 50 
                                 && this.connections.has(roomid) === false
                                 && this.recentlyClosed.includes(roomid) === false) {
 

--- a/src/global/config.js
+++ b/src/global/config.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 
 
 const wsUri = {
-    'host': 'tx-live-dmcmt-sv-01.chat.bilibili.com', 
+    'host': 'broadcastlv.chat.bilibili.com', 
     'port': 2243, 
 };
 
@@ -20,6 +20,10 @@ const raffleEmitter = new EventEmitter();
 const verbose = false;
 const debug = false;
 
+const error = {
+    'count': 0,
+};
+
 module.exports = {
     wsUri, 
     server, 
@@ -27,4 +31,5 @@ module.exports = {
     raffleEmitter, 
     verbose, 
     debug, 
+    error,
 };


### PR DESCRIPTION
- 这次的问题相当严重 且没有从根本解决的可能性
- 由于这个程序对b站服务器造成的压力极大（连接数过多），后果可能是拒绝一切请求
- 但是要想监听舰长，这种覆盖率是必须的..... 只能尽量优化筛选机制了（这个即刻执行，周二考完试就着手解决）
- 检测到拒绝请求则立即终止程序，这是最佳方案了...