### PR TITLE
Merged and refactored Pearlulu's dynamic IP assignment feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
  3. `node ./src/main.js`             (正常运行)
  4. `node ./src/main.js -v`          (显示获取到x个动态房间)
  5. `node ./src/main.js --debug`     (显示对debug有帮助的信息(自认为) !刷屏警告)
- 6. 运行后可以进浏览器<http://127.0.0.1:9001/guard>查看可领取范围内的舰长, <http://127.0.0.1:9001/gift>查看可领取范围内的抽奖, <http://127.0.0.1:9001/pk>查看可领取范围内的大乱斗奖励 (可能要等会)
+ 6. 运行后可以进浏览器<http://{ip}:9001/guard>查看可领取范围内的大航海奖励, <http://{ip}:9001/gift>查看可领取范围内的抽奖 (可能要等会), <http://{ip}:9001/pk>查看可领取范围内的大乱斗奖励
 
 ### 运行方式 (3) - 不会用命令行可以用这种方法
  1. 右键`run.ps1`, 用powershell运行
@@ -47,12 +47,32 @@
 ```javascript
 {
     "wsServer": {
-        "ip": "127.0.0.1",      // 本地localhost推送；0.0.0.0可与外网相连
-        "port": 8999            // 选个接口 (client配对)
+        "self": {
+            "ip": "127.0.0.1",              // 本地localhost推送；0.0.0.0可与外网相连
+            "port": 8999                    // 选个接口 (client配对)
+        },
+        "bilive": {                         // 兼容bilive_client的ws服务器
+            "ip": "127.0.0.1",              // 本地localhost推送；0.0.0.0可与外网相连
+            "port": 8998                    // 选个接口 (client配对)
+        },
+        "bilihelper": {                     // 还不支持
+            "ip": "127.0.0.1",
+            "port": 8997
+        }
     },
     "httpServer": {
-        "ip": "127.0.0.1",      // 同上
-        "port": 9001            // 换个别的也可以 (client配对)
+        "ip": "127.0.0.1",                  // 同上
+        "port": 9001                        // 换个别的也可以 (client配对)
+    },
+    "bilibiliIPTracker": {                  // 支持IP掉线检测和智能动态分配
+        "trackIPs": true,                   // 使用或禁用本功能
+        "dnsFailureRetries": 3,             // DNS解析错误时重试次数
+        "dnsFailureRetryDelay": 5,          // DNS解析错误时重试延时，默认5秒
+        "staticUpdateInterval": 60,         // 静态更新掉线统计间隔时长，默认60秒
+        "dynamicUpdateThreashold": 100,     // 动态更新掉线统计阈值。总掉线数达到此值将触发IP重新分配
+        "unreliableHostThreashold": 5,      // 可用IP掉线偏差阈值。每次更新时IP掉线数相较于最好的IP在偏差范围内的可被分配。数字越大得到的好IP越多，连接数越平均
+        "unusableNetworkThreshold": 0,      // 网络可用判定最小掉线数阈值。每次更新时如果最好的IP掉线数仍旧达到此值将视为当前网络不可用。默认值为0，不进行检测
+        "exitWhenNetworkUnusable": false    // 检测到网络不可用时是否退出运行。只有在unusableNetworkThreshold有设置的情况下生效
     }
 }
 ```

--- a/src/danmu/bilibilitcp.js
+++ b/src/danmu/bilibilitcp.js
@@ -38,7 +38,7 @@
 
             this.setMaxListeners(15);
 
-            this.host = wsUri.host;
+            this.host = wsUri.host.resolve();
             this.port = wsUri.port;
 
             this.roomid = roomid || 0;
@@ -94,7 +94,7 @@
         run() {
             this.reset();
             this.socket = net.createConnection({
-                'host': this.host, 
+                'host': this.host.address, 
                 'port': this.port,
             }).setKeepAlive(true); // .setNoDelay(true)
             this.socket.on('connect', this.onConnect);
@@ -135,6 +135,7 @@
         onClose() {
             this.reset();
             if (this.closed_by_user === false) {
+                this.host.reportDisconnection();
                 this.run();
             } else {
                 this.emit('close');

--- a/src/global/config.js
+++ b/src/global/config.js
@@ -4,9 +4,22 @@
 
     const settings = require('../settings.json');
     const EventEmitter = require('events').EventEmitter;
+    const HostResolver = require('../net/hostresolver.js');
+
+    const bilibiliServer = {
+        'host': 'broadcastlv.chat.bilibili.com',
+        'trackIPs': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('trackIPs') ? settings.bilibiliIPTracker.trackIPs : true,
+        'dnsFailureRetries': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('dnsFailureRetries') ? settings.bilibiliIPTracker.dnsFailureRetries : 3,
+        'dnsFailureRetryDelay': (settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('dnsFailureRetryDelay') ? settings.bilibiliIPTracker.dnsFailureRetryDelay : 5) * 1000,
+        'staticUpdateInterval': (settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('staticUpdateInterval') ? settings.bilibiliIPTracker.staticUpdateInterval : 60) * 1000,
+        'dynamicUpdateThreashold': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('dynamicUpdateThreashold') ? settings.bilibiliIPTracker.dynamicUpdateThreashold : 100,
+        'unreliableHostThreashold': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('unreliableHostThreashold') ? settings.bilibiliIPTracker.unreliableHostThreashold : 5,
+        'unusableNetworkThreshold': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('unusableNetworkThreshold') ? settings.bilibiliIPTracker.unusableNetworkThreshold : 0,
+        'exitWhenNetworkUnusable': settings.bilibiliIPTracker && settings.bilibiliIPTracker.hasOwnProperty('exitWhenNetworkUnusable') ? settings.bilibiliIPTracker.exitWhenNetworkUnusable : false
+    };
 
     const wsUri = {
-        'host': 'broadcastlv.chat.bilibili.com',
+        'host': new HostResolver(bilibiliServer.host, bilibiliServer),
         'port': 2243,
     };
 
@@ -132,6 +145,7 @@
         FIXED,
         DYNAMIC_1,
         DYNAMIC_2,
+        bilibiliServer,
         wsUri,
         wsServer,
         httpServer,

--- a/src/net/hostresolver.js
+++ b/src/net/hostresolver.js
@@ -1,0 +1,151 @@
+(function() {
+
+    'use strict';
+
+    const dns = require('dns');
+    const cprint = require('../util/printer.js');
+    const colors = require('colors/safe');
+
+    class ResolvedHost {
+
+        /**
+         * @constructor
+         * @param   {string}       address
+         * @param   {HostResolver} resolver
+         */
+        constructor(address, resolver) {
+            this._address = address;
+            this._resolver = resolver;
+        }
+
+        get address() {
+            return this._address;
+        }
+
+        reportDisconnection() {
+            // Report and get a new address from resolver.
+            this._resolver.reportDisconnection(this._address);
+            this._address = this._resolver.resolve().address;
+        }
+    }
+
+    class HostResolver {
+
+        /**
+         * @constructor
+         * @param   {string}   host
+         * @param   {any}      options
+         */
+        constructor(host, options) {
+            this._host = host;
+
+            if (options) {
+                this._options = options;
+            } else {
+                this._options = {
+                    'trackIPs': true, // 使用IP掉线检测和智能动态分配
+                    'dnsFailureRetries': 3, // DNS解析错误时重试次数
+                    'dnsFailureRetryDelay': 1000 * 5, // DNS解析错误时重试延时，默认5秒
+                    'staticUpdateInterval': 1000 * 60, // 静态更新掉线统计间隔时长，默认60秒
+                    'dynamicUpdateThreashold': 100, // 动态更新掉线统计阈值
+                    'unreliableHostThreashold': 5, // 可用IP掉线偏差阈值。数字越大得到的好IP越多，连接数越平均
+                    'unusableNetworkThreshold': 0, // 网络可用判定最小掉线数阈值，默认值为0，不进行检测
+                    'exitWhenNetworkUnusable': false // 网络不可用时是否退出
+                }
+            }
+
+            if (this._options.trackIPs) {
+                this._initialized = false;
+                this._hostIPs = new Map(); // DNS返回IP列表
+                this._count = 0; // 掉线次数统计
+            }
+        }
+
+        // 初始化IP数据
+        resolveDns() {
+            dns.resolve(this._host, (err, records) => {
+                if (!err) {
+                    for (const ip of records) {
+                        this._hostIPs.set(ip, 0);
+                    }
+                    this._goodIPs = records.slice(); // 网络较好IP
+                    this._lastIPIndex = -1; // IP连接顺序
+
+                    // 固定时间更新掉线统计
+                    this._updateTask = setInterval(() => this.update(), this._options.staticUpdateInterval);
+                } else {
+                    cprint(`HostResolver - DNS resolve failure: ${err.message}`, colors.red);
+                    if (this._dnsFailureRetries-- > 0) {
+                        setTimeout(() => this.resolveDns(), this._options.dnsFailureRetryDelay);
+                    }
+                }
+            });
+        }
+
+        reportDisconnection(address) {
+            // 记录掉线IP
+            if (this._options.trackIPs && this._hostIPs.has(address)) {
+                //cprint(`HostResolver - Disconncetion reported: ${address}`, colors.yellow);
+                this._hostIPs.set(address, this._hostIPs.get(address) + 1);
+
+                // 记录请求次数，动态更新掉线统计
+                if (++this._count >= this._options.dynamicUpdateThreashold) {
+                    this.update();
+                }
+            }
+        }
+
+        resolve() {
+            // 禁用追踪
+            if (!this._options.trackIPs) {
+                return new ResolvedHost(this._host, this);
+            }
+
+            // 尚未获取IP
+            if (this._hostIPs.size === 0) {
+                if (!this._initialized) {
+                    this._dnsFailureRetries = this._options.dnsFailureRetries;
+                    this.resolveDns();
+                    this._initialized = true;
+                }
+                return new ResolvedHost(this._host, this);
+            }
+
+            // 根据goodIPs列表轮换IP
+            if (++this._lastIPIndex >= this._goodIPs.length) {
+                this._lastIPIndex = 0;
+            }
+            return new ResolvedHost(this._goodIPs[this._lastIPIndex], this);
+        }
+
+         // 更新掉线统计
+        update() {
+            this._count = 0;
+
+            // 更新网络较好IP列表
+            const minCount = Math.min(...this._hostIPs.values());
+            if (this._unusableNetworkThreshold > 0 && minCount > this._options.unusableNetworkThreshold) {
+                // 掉线率过高
+                cprint(`HostResolver - high rate of disconnections: ${minCount}`, colors.red);
+                if (this._options.exitWhenNetworkUnusable) {
+                    process.exit(1);
+                } else {
+                    // 重新平均分配IP
+                    this._goodIPs = [...this._hostIPs.keys()];
+                }
+            } else {
+                this._goodIPs = [];
+                for (const [ip, count] of this._hostIPs) {
+                    //cprint(`HostResolver - ${ip} disconnection count: ${count}`, colors.yellow);
+                    if (count - minCount <= this._options.unreliableHostThreashold) {
+                        this._goodIPs.push(ip);
+                    }
+                    this._hostIPs.set(ip, 0);
+                }
+            }
+        }
+    };
+
+    module.exports = HostResolver;
+
+})();

--- a/src/settings.json
+++ b/src/settings.json
@@ -16,5 +16,15 @@
     "httpServer": {
         "ip": "0.0.0.0",
         "port": 9001
+    },
+    "bilibiliIPTracker": {
+        "trackIPs": true,
+        "dnsFailureRetries": 3,
+        "dnsFailureRetryDelay": 5,
+        "staticUpdateInterval": 60,
+        "dynamicUpdateThreashold": 100,
+        "unreliableHostThreashold": 5,
+        "unusableNetworkThreshold": 0,
+        "exitWhenNetworkUnusable": false
     }
 }


### PR DESCRIPTION
I can't say for sure how much it helps on Windows platform, as in general the network layer is not great. Extensive testing would be needed to gather more data. Though, it certainly dynamically adjusts IPs assigned to connections. Usually I see lots of dropped connections from 120.92.112.150 and 120.92.78.57. As a result, over time these 2 IPs tend to get fewer connections.

You may want to merge it to linux branch and try on a Linux server to see if it improves coverage. Since it's an experimental feature, I made almost everything configurable so you can play with different parameters. If this helps we can bring it to TS version.